### PR TITLE
Source archives for Databinder-Dispatch

### DIFF
--- a/project/build/DispatchProject.scala
+++ b/project/build/DispatchProject.scala
@@ -48,6 +48,9 @@ class DispatchProject(info: ProjectInfo) extends ParentProject(info) with poster
         "org.scala-tools.testing" % "specs" % "1.6.2.2" % "test->default"
       else
         "org.scala-tools.testing" %% "specs" % "1.6.5" % "test->default"
+    override def packageSrcJar = defaultJarPath("-sources.jar")
+    lazy val sourceArtifact = Artifact.sources(artifactID)
+    override def packageToPublishActions = super.packageToPublishActions ++ Seq(packageSrc)
   }
     
   class HttpProject(info: ProjectInfo) extends DispatchModule(info) {


### PR DESCRIPTION
Hi,

I got tired of not being able to look up code easily, so I ended up toying around with the build.

Following SBT documentation regarding attachment of source archives to artifacts resulted in SBT complaining about missing 'project.name' values in subproject 'build.properties' files -- frustrating, especially considering that those values are supplied as parameters to 'project()' and should generally be available.

However, turns out that if you make the source artifact lazy, everything works fine.

Hopefully, everyone will now be able to enjoy Dispatch with sources attached.

-Nadav.
