### PR TITLE
Version 0.8.1 including lift-json 2.3, appengine 1.3.6 and the idea sbt plugin.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ project/boot
 project/plugins/project
 src_managed
 *.test.properties
+.idea
+*.iml

--- a/lift-json/src/main/scala/LiftJson.scala
+++ b/lift-json/src/main/scala/LiftJson.scala
@@ -2,7 +2,6 @@ package dispatch.liftjson
 import dispatch._
 
 import net.liftweb.json._
-import JsonAST._
 import JsonDSL._
 
 import java.util.Date

--- a/meetup/src/main/scala/Everywhere.scala
+++ b/meetup/src/main/scala/Everywhere.scala
@@ -4,7 +4,6 @@ import dispatch._
 
 import dispatch.liftjson.Js._
 import net.liftweb.json._
-import net.liftweb.json.JsonAST._
 
 import dispatch.mime.Mime._
 import dispatch.Request._

--- a/meetup/src/main/scala/Meetup.scala
+++ b/meetup/src/main/scala/Meetup.scala
@@ -7,7 +7,6 @@ import dispatch.oauth.OAuth._
 
 import dispatch.liftjson.Js._
 import net.liftweb.json._
-import net.liftweb.json.JsonAST._
 
 import dispatch.mime.Mime._
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -2,7 +2,7 @@
 #Tue Dec 22 22:49:10 EST 2009
 project.name=Dispatch
 project.organization=net.databinder
-project.version=0.8.0
+project.version=0.8.1
 sbt.version=0.7.4
 def.scala.version=2.7.7
-build.scala.versions=2.9.0.RC1 2.8.1 2.8.0
+build.scala.versions=2.8.1 2.9.0.RC1 2.8.0

--- a/project/build/DispatchProject.scala
+++ b/project/build/DispatchProject.scala
@@ -5,6 +5,7 @@ class DispatchProject(info: ProjectInfo)
   extends ParentProject(info) 
   with posterous.Publish
   with gh.Issues
+  with IdeaProject
 {
   override def parallelExecution = true
 
@@ -23,11 +24,11 @@ class DispatchProject(info: ProjectInfo)
   lazy val http_json = project("http+json", "Dispatch HTTP JSON", new HttpProject(_), core, json)
   lazy val http_gae = project("http-gae", "Dispatch HTTP GAE", new HttpProject(_) {
     val bum_gae = "bumnetworks GAE artifacts" at "http://www.bumnetworks.com/gae"
-    val gae_api = "com.google.appengine" % "appengine-api-1.0-sdk" % "1.3.4"
+    val gae_api = "com.google.appengine" % "appengine-api-1.0-sdk" % "1.3.6"
   }, d_http)
 
   lazy val lift_json = project("lift-json", "Dispatch lift-json", new DispatchModule(_) {
-    val lift_json = "net.liftweb" % "lift-json_2.8.1" % "2.2"
+    val lift_json = "net.liftweb" % "lift-json_2.8.1" % "2.3"
   }, core)
   lazy val oauth = project("oauth", "Dispatch OAuth", new DispatchModule(_), core)
   lazy val times = project("times", "Dispatch Times", new DispatchModule(_), d_http, json, http_json)
@@ -52,10 +53,10 @@ class DispatchProject(info: ProjectInfo)
   val sxr_version = "0.2.3"
 
   override def managedStyle = ManagedStyle.Maven
-  val publishTo = "Scala Tools Nexus" at "http://nexus.scala-tools.org/content/repositories/releases/"
+  val publishTo = "Mimesis Nexus" at "http://10.101.0.202:8081/nexus/content/repositories/3rdparty/"
   Credentials(Path.userHome / ".ivy2" / ".credentials", log)
 
-  class DispatchModule(info: ProjectInfo) extends DefaultProject(info) with sxr.Publish {
+  class DispatchModule(info: ProjectInfo) extends DefaultProject(info) with sxr.Publish with IdeaProject {
     val specs = "org.scala-tools.testing" % "specs_2.8.1" % "1.6.7" % "test->default"
     override def packageSrcJar = defaultJarPath("-sources.jar")
     lazy val sourceArtifact = Artifact.sources(artifactID)

--- a/project/plugins/Plugins.scala
+++ b/project/plugins/Plugins.scala
@@ -12,4 +12,7 @@ class Plugins(info: ProjectInfo) extends PluginDefinition(info) {
 
   val lessis = "less is repo" at "http://repo.lessis.me"
   val ghIssues = "me.lessis" % "sbt-gh-issues" % "0.1.0"
+
+  val sbtIdeaRepo = "sbt-idea-repo" at "http://mpeltonen.github.com/maven/"
+  val sbtIdea = "com.github.mpeltonen" % "sbt-idea-plugin" % "0.4.0"
 }


### PR DESCRIPTION
Minor changes for personal convinience which might or might not be worth integrating.

I need the lift-json upgrade because I directly use it in other parts of my project.
As for the appengine, I noticed that the version 1.3.4 is not available from the repository you point to, nor from mvnrepository.
IDEA is just the IDE we happen to use here for Scala.

Unit tests ran fine with the exception of the CloudDB ones (I did not have a CloudDB test instance at hand).
