### PR TITLE
Specify make_client return type to allow override

### DIFF
--- a/http/src/main/scala/thread/thread.scala
+++ b/http/src/main/scala/thread/thread.scala
@@ -1,9 +1,8 @@
 package dispatch.thread
 
-import org.apache.http.{HttpHost,HttpRequest,HttpResponse}
-import org.apache.http.client.methods.HttpRequestBase
 import dispatch._
 import dispatch.futures._
+import org.apache.http.client.HttpClient
 
 /** Http with a thread-safe client */
 trait Safety { self: BlockingHttp =>
@@ -13,7 +12,7 @@ trait Safety { self: BlockingHttp =>
   def maxConnectionsPerRoute = maxConnections
   /** Shutdown connection manager if no longer in use. */
 
-  override def make_client = new ThreadSafeHttpClient(
+  override def make_client: HttpClient = new ThreadSafeHttpClient(
     credentials, maxConnections, maxConnectionsPerRoute)
 }
 
@@ -36,8 +35,6 @@ class ThreadSafeHttpClient(
   maxConnections: Int, 
   maxConnectionsPerRoute: Int
 ) extends ConfiguredHttpClient(credentials) {
-  import org.apache.http.conn.scheme.{Scheme,SchemeRegistry,PlainSocketFactory}
-  import org.apache.http.conn.ssl.SSLSocketFactory
   import org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager
   override def createClientConnectionManager = {
     val cm = new ThreadSafeClientConnManager()


### PR DESCRIPTION
Scala narrows the return type of an overridden method to the inferred type of the overriding method.  This prevents subclasses from further overriding according to the original type, HttpClient.  Specify HttpClient explicitly so that any subclass can override make_client.

I think I saw somewhere that this change had been made to one of the classes that overrides make_client.  There are still a few overriders (nio.Http, gae.Http) that use the inferred type that should presumably also get this change.  I only updated the one we're using and added a test for it (that only checks that it can compile, really).

Thanks,
Oliver
