### PR TITLE
Adding ByteArrayEntity wrapping << method to POST arbitrary binary data

### DIFF
--- a/core/src/main/scala/requests.scala
+++ b/core/src/main/scala/requests.scala
@@ -3,7 +3,7 @@ package dispatch
 import org.apache.http.message.BasicHttpRequest
 import org.apache.http.{HttpEntity,HttpHost,HttpRequest}
 import org.apache.http.util.EntityUtils
-import org.apache.http.entity.StringEntity
+import org.apache.http.entity.{StringEntity, ByteArrayEntity}
 import java.net.URI
 
 object Request extends Encoders
@@ -190,6 +190,10 @@ class RequestVerbs(subject: Request) {
   def << (stringbody: String, contenttype: String): Request = POST.copy(
     body=Some(new RefStringEntity(
       stringbody, contenttype, subject.defaultCharset))
+  )
+  /** Post the given byte array. */
+  def << (contents: Array[Byte]): Request = POST.copy(
+    body=Some(new ByteArrayEntity(contents))
   )
   
   /** Add query parameters. (mutates request) */


### PR DESCRIPTION
N8than,

I spent a while trying to POST a byte array from a protobuf using << method and I was getting some weird results. I then switched back HttpClient (ugh) and used ByteArrayEntity and it worked fine. Is this a reasonable patch? Anything else you want me to do?

Thanks,

David
