### PR TITLE
Improve JSON output code

### DIFF
--- a/json/src/main/scala/Json.scala
+++ b/json/src/main/scala/Json.scala
@@ -6,7 +6,7 @@ import scala.util.parsing.combinator._
 import scala.util.parsing.combinator.syntactical._
 import scala.util.parsing.combinator.lexical._
 import scala.util.parsing.input.{CharSequenceReader,CharArrayReader}
-import java.io.{StringWriter, Writer, InputStream, InputStreamReader}
+import java.io.{InputStream, InputStreamReader}
 
 object JsonParser extends StdTokenParsers with ImplicitConversions {
   type Tokens = scala.util.parsing.json.Lexer
@@ -122,56 +122,56 @@ object JsValue {
     JsonParser(new CharArrayReader(io.Source.fromInputStream(s, charset).mkString.toCharArray))
 
   def toJson(x: JsValue): String = {
-    val w = new StringWriter
+    val w = new java.lang.StringBuilder
     writeJson(x, w)
     w.toString
   }
 
-  def writeJson(x: JsValue, w: Writer) {
+  def writeJson(x: JsValue, w: Appendable) {
     x match {
-      case JsNull => w.write("null")
-      case JsBoolean(b) => w.write(b.toString)
-      case JsNumber(n) => w.write(n.toString)
+      case JsNull => w.append("null")
+      case JsBoolean(b) => w.append(b.toString)
+      case JsNumber(n) => w.append(n.toString)
       case JsString(s) => {
-        w.write("\"")
+        w.append("\"")
         s foreach {
-          case '\\' => w.write("\\\\")
-          case '\n' => w.write("\\n")
-          case '\r' => w.write("\\r")
-          case '\t' => w.write("\\t")
-          case '"' => w.write("\\\"")
-          case c if c <= 0x1F => w.write("\\u%04x".format(c.toInt))
-          case c => w.write(c)
+          case '\\' => w.append("\\\\")
+          case '\n' => w.append("\\n")
+          case '\r' => w.append("\\r")
+          case '\t' => w.append("\\t")
+          case '"' => w.append("\\\"")
+          case c if c <= 0x1F => w.append("\\u%04x".format(c.toInt))
+          case c => w.append(c)
         }
-        w.write("\"")
+        w.append("\"")
       }
       case JsArray(ys) => {
-        w.write("[")
+        w.append("[")
         var first = true
         for (y <- ys) {
           if (first) {
             first = false
           } else {
-            w.write(", ")
+            w.append(", ")
           }
           writeJson(y, w)
         }
-        w.write("]")
+        w.append("]")
       }
       case JsObject(m) => {
-        w.write("{")
+        w.append("{")
         var first = true
         for ((k,v) <- m) {
           if (first) {
             first = false
           } else {
-            w.write(", ")
+            w.append(", ")
           }
           writeJson(k, w)
-          w.write(": ")
+          w.append(": ")
           writeJson(v, w)
         }
-        w.write("}")
+        w.append("}")
       }
     }
   }

--- a/json/src/test/scala/JsonSpec.scala
+++ b/json/src/test/scala/JsonSpec.scala
@@ -56,6 +56,9 @@ object JsValueSpec extends Specification {
         JsObject(Map(JsString("scrolls") -> JsArray(List(JsString("identify"))),
                      JsString("name") -> JsString("foo"))))
     }
+    "round-trip Unicode string" in {
+      reparse("control \u0008") must be equalTo(JsString("control \u0008"))
+    }
   }
 
   "JsValue.fromString and JsValue.fromStream" should {

--- a/json/src/test/scala/JsonSpec.scala
+++ b/json/src/test/scala/JsonSpec.scala
@@ -12,12 +12,59 @@ object JsValueSpec extends Specification {
     (block, System.currentTimeMillis - start)
   }
 
+  def reparse(x: Any) = Js(JsValue(x).toString)
+
+  "JS parsing" should {
+    "parse null" in {
+      Js("null") must be equalTo(JsNull)
+    }
+    "parse true" in {
+      Js("true") must be equalTo(JsTrue)
+    }
+    "parse false" in {
+      Js("false") must be equalTo(JsFalse)
+    }
+    "parse number" in {
+      Js("2394.3") must be equalTo(JsNumber(BigDecimal(2394.3)))
+    }
+    "parse string" in {
+      Js("\"foobie bletch\"") must be equalTo(JsString("foobie bletch"))
+    }
+    "parse escaped string" in {
+      Js("\"hello\\u203D\"") must be equalTo(JsString("hello\u203d"))
+    }
+    "parse array" in {
+      Js("[\"foo\", \"bar\"]") must be equalTo(JsArray(List(JsString("foo"), JsString("bar"))))
+    }
+    "parse object" in {
+      Js("{\"foo\": true}") must be equalTo(JsObject(Map(JsString("foo") -> JsTrue)))
+    }
+  }
+  
+  "JS round-tripping" should {
+    "round-trip null" in {
+      reparse(null) must be equalTo(JsNull)
+    }
+    "round-trip string" in {
+      reparse("HACKEM MUCHE") must be equalTo(JsString("HACKEM MUCHE"))
+    }
+    "round-trip array" in {
+      reparse(List("foo", false)) must be equalTo(JsArray(List(JsString("foo"), JsFalse)))
+    }
+    "round-trip object" in {
+      reparse(Map("scrolls" -> List("identify"), "name" -> "foo")) must be equalTo(
+        JsObject(Map(JsString("scrolls") -> JsArray(List(JsString("identify"))),
+                     JsString("name") -> JsString("foo"))))
+    }
+  }
+
   "JsValue.fromString and JsValue.fromStream" should {
+    val maxTime = 1000L
     "not become slow under alternate calling" in {
       val (_, t1) = time { JsValue.fromString(json) }
-      t1 must be_<=(1000L)  // normally finish within 1s
+      t1 must be_<=(maxTime)  // normally finish within 1s
       val (_, t2) = time { JsValue.fromStream(new ByteArrayInputStream(json.getBytes("utf-8"))) }
-      t2 must be_<=(1000L)
+      t2 must be_<=(maxTime)
     }
     
     "work properly under multi-thread calling" in {
@@ -32,7 +79,7 @@ object JsValueSpec extends Specification {
           })
         executor.execute(f)
         f
-      }.map{_.get}.toList mustNotExist {case (_, t) => t > 1000}
+      }.map{_.get}.toList mustNotExist {case (_, t) => t > maxTime}
     }
   }
 }


### PR DESCRIPTION
Adds test cases for JSON parsing/serialization & improves JSON serialization in 2 ways:
- Provide `JsValue.writeJson` method that writes JSON to an `Appendable`, using this method with a `StringBuilder` in `toString`, so that JSON isn't built by string concatenation & can be output directly to a writer.
- Encode more characters when outputting strings, especially the illegal control characters (U+0000-U+001F). Previously, if a string contained a control character, it was output unencoded, which is illegal JSON.
