### PR TITLE
Fix if system porperty, "https.proxyPort" and etc, is "" but not null.

### DIFF
--- a/http/src/main/scala/ConfiguredHttpClient.scala
+++ b/http/src/main/scala/ConfiguredHttpClient.scala
@@ -28,12 +28,12 @@ class ConfiguredHttpClient(
                                    sys.getProperty("http.proxyPassword"))
     val domain = sys.getProperty("https.auth.ntlm.domain",
                                  sys.getProperty("http.auth.ntlm.domain"))
-    if (host != null && port != null) {
+    if (host != null && !host.trim.isEmpty && port != null && !port.trim.isEmpty) {
       ConnRouteParams.setDefaultProxy(params,
                                       new HttpHost(host, port.toInt))
       proxyScope = Some(new AuthScope(host, port.toInt))
     }
-    if (user != null && password != null) {
+    if (user != null && !user.trim.isEmpty && password != null && !password.trim.isEmpty) {
       proxyBasicCredentials =
         Some(new UsernamePasswordCredentials(user, password))
       // We should pass our hostname, actually


### PR DESCRIPTION
I have a very strange error.
It's caused by "https.proxyPort" being "", so it cannot be parsed to Int.
When I use `new Http`, I encountered this error. But when I use `Http` object, this error disappeared.

This patch can fix this error. 
