### PR TITLE
First round of a simple userless foursquare request.

### DIFF
--- a/oauth/src/main/scala/foursquare.scala
+++ b/oauth/src/main/scala/foursquare.scala
@@ -1,0 +1,11 @@
+package dispatch.foursquare
+import dispatch._
+
+object Auth {
+  private val svc: Request = :/ ("api.foursquare.com") secure
+
+  def apply(version: String, creds: Pair[String, String], request: Request): Request = {
+    (svc / version) <& request <<? Map("client_id" -> creds._1, "client_secret" -> creds._2)
+  }
+
+}

--- a/oauth/src/main/scala/foursquare.scala
+++ b/oauth/src/main/scala/foursquare.scala
@@ -4,8 +4,8 @@ import dispatch._
 object Auth {
   private val svc: Request = :/ ("api.foursquare.com") secure
 
-  def apply(version: String, creds: Pair[String, String], request: Request): Request = {
-    (svc / version) <& request <<? Map("client_id" -> creds._1, "client_secret" -> creds._2)
+  def apply(creds: Pair[String, String])(request: Request): Request = {
+    svc <& request <<? Map("client_id" -> creds._1, "client_secret" -> creds._2)
   }
 
 }

--- a/oauth/src/main/scala/foursquare.scala
+++ b/oauth/src/main/scala/foursquare.scala
@@ -4,6 +4,9 @@ import dispatch._
 object Auth {
   private val svc: Request = :/ ("api.foursquare.com") secure
 
+  def apply(key: String, secret: String)(request: Request): Request =
+    apply((key, secret))(request)
+
   def apply(creds: Pair[String, String])(request: Request): Request = {
     svc <& request <<? Map("client_id" -> creds._1, "client_secret" -> creds._2)
   }

--- a/oauth/src/test/scala/foursquare.scala
+++ b/oauth/src/test/scala/foursquare.scala
@@ -1,0 +1,23 @@
+package dispatch.foursquare
+
+import dispatch._
+import org.specs._
+
+object FoursquareSpec extends Specification {
+  "A basic foursquare request that requires auth" should {
+    "be able to be formed normally" in new context {
+      val builtReq = Auth("v2", ("key", "secret"), req).to_uri.toString
+
+      builtReq.contains("api.foursquare.com/v2/venues/search") must_== true
+      builtReq.contains("client_id=key") must_== true
+      builtReq.contains("client_secret=secret") must_== true
+      builtReq.contains("ll=123.123%2C456.456") must_== true
+      builtReq.contains("v=19700101") must_== true
+      builtReq.contains("https://") must_== true
+    }
+  }
+}
+
+trait context {
+  val req = /\ / "venues" / "search" <<? Map("ll" -> "123.123,456.456", "v" -> "19700101")
+}

--- a/oauth/src/test/scala/foursquare.scala
+++ b/oauth/src/test/scala/foursquare.scala
@@ -15,6 +15,17 @@ object FoursquareSpec extends Specification {
       builtReq.contains("v=19700101") must_== true
       builtReq.contains("https://") must_== true
     }
+
+    "be able to be formed normally through other apply" in new context {
+      val builtReq = Auth("key", "secret")(req).to_uri.toString
+
+      builtReq.contains("api.foursquare.com/v2/venues/search") must_== true
+      builtReq.contains("client_id=key") must_== true
+      builtReq.contains("client_secret=secret") must_== true
+      builtReq.contains("ll=123.123%2C456.456") must_== true
+      builtReq.contains("v=19700101") must_== true
+      builtReq.contains("https://") must_== true
+    }
   }
 }
 

--- a/oauth/src/test/scala/foursquare.scala
+++ b/oauth/src/test/scala/foursquare.scala
@@ -6,7 +6,7 @@ import org.specs._
 object FoursquareSpec extends Specification {
   "A basic foursquare request that requires auth" should {
     "be able to be formed normally" in new context {
-      val builtReq = Auth("v2", ("key", "secret"), req).to_uri.toString
+      val builtReq = Auth(("key", "secret"))(req).to_uri.toString
 
       builtReq.contains("api.foursquare.com/v2/venues/search") must_== true
       builtReq.contains("client_id=key") must_== true
@@ -19,5 +19,5 @@ object FoursquareSpec extends Specification {
 }
 
 trait context {
-  val req = /\ / "venues" / "search" <<? Map("ll" -> "123.123,456.456", "v" -> "19700101")
+  val req = /\ / "v2" / "venues" / "search" <<? Map("ll" -> "123.123,456.456", "v" -> "19700101")
 }


### PR DESCRIPTION
I noticed there was a simple twitter oauth helper so I figured I could whip up one just as easily for foursquare.

They offer two forms of authed connections, userless and full blown oauth. This is just the userless connection, but I could add in the full oauth before this would be merged in.

For docs on userless: https://developer.foursquare.com/overview/auth#userless
